### PR TITLE
Migrate Todoist SDK from v3 to v6

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -11,6 +11,9 @@ if you want to view the source, please visit the github repository of this plugi
 
 const prod = (process.argv[2] === "production");
 
+// Generate node: prefixed versions of all builtins for undici/SDK compatibility
+const nodeBuiltins = builtins.map(m => `node:${m}`);
+
 const buildOptions = {
     banner: {
         js: banner,
@@ -20,6 +23,7 @@ const buildOptions = {
     external: [
         "obsidian",
         "electron",
+        "undici",
         "@codemirror/autocomplete",
         "@codemirror/collab",
         "@codemirror/commands",
@@ -31,7 +35,8 @@ const buildOptions = {
         "@lezer/common",
         "@lezer/highlight",
         "@lezer/lr",
-        ...builtins],
+        ...builtins,
+        ...nodeBuiltins],
     format: "cjs",
     target: "es2018",
     logLevel: "info",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "todoist-context-bridge",
             "version": "1.1.0",
             "dependencies": {
-                "@doist/todoist-api-typescript": "^3.0.3",
+                "@doist/todoist-api-typescript": "^6.10.0",
                 "moment": "^2.29.4"
             },
             "devDependencies": {
@@ -19,7 +19,7 @@
                 "builtin-modules": "3.3.0",
                 "esbuild": "0.25.0",
                 "jest": "^29.7.0",
-                "obsidian": "*",
+                "obsidian": "latest",
                 "prettier": "^3.4.1",
                 "ts-jest": "^29.1.1",
                 "tslib": "2.4.0",
@@ -71,6 +71,7 @@
             "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.0",
@@ -491,15 +492,6 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/runtime": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-            "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/template": {
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
@@ -587,21 +579,43 @@
             }
         },
         "node_modules/@doist/todoist-api-typescript": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-3.0.3.tgz",
-            "integrity": "sha512-rDYE6X/xSF+b+fvRYoVyBa7EaUOSIKhTrn7/XxV3Fm2rQrK61SoImor5pyWZlMiABH44WMf+FBIh+IjGAGaX3Q==",
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-6.10.0.tgz",
+            "integrity": "sha512-obSwvJLSA4/8Sw6xbse8OL+Oq7l//+JtwtVissTEZ/9NTjRrdS/jqykgaiviW1wHUWZWf1LY7RVDKfRjCzaghA==",
             "license": "MIT",
             "dependencies": {
-                "axios": "^1.0.0",
-                "axios-case-converter": "^1.0.0",
-                "axios-retry": "^3.1.9",
-                "runtypes": "^6.5.0",
+                "camelcase": "6.3.0",
+                "emoji-regex": "10.6.0",
+                "form-data": "4.0.5",
                 "ts-custom-error": "^3.2.0",
-                "uuid": "^9.0.0"
+                "undici": "^7.16.0",
+                "uuid": "11.1.0",
+                "zod": "4.3.6"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "type-fest": "^4.12.0"
             }
+        },
+        "node_modules/@doist/todoist-api-typescript/node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@doist/todoist-api-typescript/node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.0",
@@ -1063,7 +1077,6 @@
             "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -1088,7 +1101,6 @@
             "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
@@ -1100,7 +1112,6 @@
             "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^2.0.3",
                 "debug": "^4.3.1",
@@ -1116,7 +1127,6 @@
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -1131,8 +1141,7 @@
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "deprecated": "Use @eslint/object-schema instead",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -1870,6 +1879,7 @@
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -2030,8 +2040,7 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/acorn": {
             "version": "8.14.0",
@@ -2053,7 +2062,6 @@
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -2064,7 +2072,6 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -2150,8 +2157,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
-            "license": "Python-2.0",
-            "peer": true
+            "license": "Python-2.0"
         },
         "node_modules/array-union": {
             "version": "2.1.0",
@@ -2175,42 +2181,6 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "license": "MIT"
-        },
-        "node_modules/axios": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-            "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
-        "node_modules/axios-case-converter": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/axios-case-converter/-/axios-case-converter-1.1.1.tgz",
-            "integrity": "sha512-v13pB7cYryh/7f4TKxN/gniD2hwqPQcjip29Hk3J9iwsnA37Rht2Hkn5VyrxynxlKdMNSIfGk6I9D6G28oTRyQ==",
-            "license": "MIT",
-            "dependencies": {
-                "camel-case": "^4.1.1",
-                "header-case": "^2.0.3",
-                "snake-case": "^3.0.3",
-                "tslib": "^2.3.0"
-            },
-            "peerDependencies": {
-                "axios": ">=1.0.0 <2.0.0"
-            }
-        },
-        "node_modules/axios-retry": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
-            "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@babel/runtime": "^7.15.4",
-                "is-retry-allowed": "^2.2.0"
-            }
         },
         "node_modules/babel-jest": {
             "version": "29.7.0",
@@ -2389,6 +2359,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001669",
                 "electron-to-chromium": "^1.5.41",
@@ -2468,16 +2439,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/camel-case": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-            "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-            "license": "MIT",
-            "dependencies": {
-                "pascal-case": "^3.1.2",
-                "tslib": "^2.0.3"
-            }
-        },
         "node_modules/camelcase": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2508,17 +2469,6 @@
                 }
             ],
             "license": "CC-BY-4.0"
-        },
-        "node_modules/capital-case": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-            "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-            "license": "MIT",
-            "dependencies": {
-                "no-case": "^3.0.4",
-                "tslib": "^2.0.3",
-                "upper-case-first": "^2.0.2"
-            }
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -2724,8 +2674,7 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -2785,22 +2734,11 @@
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
             "engines": {
                 "node": ">=6.0.0"
-            }
-        },
-        "node_modules/dot-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-            "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-            "license": "MIT",
-            "dependencies": {
-                "no-case": "^3.0.4",
-                "tslib": "^2.0.3"
             }
         },
         "node_modules/dunder-proto": {
@@ -2972,7 +2910,6 @@
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -3071,7 +3008,6 @@
             "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -3089,7 +3025,6 @@
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -3100,7 +3035,6 @@
             "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
@@ -3133,7 +3067,6 @@
             "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -3147,7 +3080,6 @@
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -3191,7 +3123,6 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3251,8 +3182,7 @@
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-glob": {
             "version": "3.3.2",
@@ -3296,8 +3226,7 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fastq": {
             "version": "1.17.1",
@@ -3325,7 +3254,6 @@
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -3385,7 +3313,6 @@
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -3403,7 +3330,6 @@
             "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.3",
@@ -3418,38 +3344,18 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
             "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
+            "license": "ISC"
         },
         "node_modules/form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -3595,7 +3501,6 @@
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -3609,7 +3514,6 @@
             "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -3626,7 +3530,6 @@
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -3730,16 +3633,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/header-case": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-            "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-            "license": "MIT",
-            "dependencies": {
-                "capital-case": "^1.0.4",
-                "tslib": "^2.0.3"
-            }
-        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3773,7 +3666,6 @@
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -3916,21 +3808,8 @@
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-retry-allowed": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-            "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-stream": {
@@ -4049,6 +3928,7 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -4639,7 +4519,6 @@
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -4665,8 +4544,7 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -4680,16 +4558,14 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -4710,7 +4586,6 @@
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -4741,7 +4616,6 @@
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -4763,7 +4637,6 @@
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -4786,17 +4659,7 @@
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/lower-case": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-            "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.3"
-            }
+            "license": "MIT"
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -4955,16 +4818,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/no-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-            "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-            "license": "MIT",
-            "dependencies": {
-                "lower-case": "^2.0.2",
-                "tslib": "^2.0.3"
-            }
-        },
         "node_modules/node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5049,7 +4902,6 @@
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -5084,7 +4936,6 @@
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -5111,7 +4962,6 @@
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -5136,16 +4986,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pascal-case": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-            "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-            "license": "MIT",
-            "dependencies": {
-                "no-case": "^3.0.4",
-                "tslib": "^2.0.3"
             }
         },
         "node_modules/path-exists": {
@@ -5300,7 +5140,6 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -5363,19 +5202,12 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
-        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5482,7 +5314,6 @@
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5515,7 +5346,6 @@
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -5549,12 +5379,6 @@
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
-        },
-        "node_modules/runtypes": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.7.0.tgz",
-            "integrity": "sha512-3TLdfFX8YHNFOhwHrSJza6uxVBmBrEjnNQlNXvXCdItS0Pdskfg5vVXUTWIN+Y23QR09jWpSl99UHkA83m4uWA==",
-            "license": "MIT"
         },
         "node_modules/semver": {
             "version": "7.6.3",
@@ -5614,16 +5438,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/snake-case": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-            "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-            "license": "MIT",
-            "dependencies": {
-                "dot-case": "^3.0.4",
-                "tslib": "^2.0.3"
             }
         },
         "node_modules/source-map": {
@@ -5757,8 +5571,7 @@
             "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
             "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -5806,8 +5619,7 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -5891,6 +5703,7 @@
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tsutils": {
@@ -5922,7 +5735,6 @@
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -5959,12 +5771,22 @@
             "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/undici": {
+            "version": "7.22.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+            "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
@@ -6005,37 +5827,27 @@
                 "browserslist": ">= 4.21.0"
             }
         },
-        "node_modules/upper-case-first": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-            "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.0.3"
-            }
-        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
         },
         "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {
@@ -6058,8 +5870,7 @@
             "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
             "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/walker": {
             "version": "1.0.8",
@@ -6093,7 +5904,6 @@
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -6194,6 +6004,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+            "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "typescript": "~5.1.6"
     },
     "dependencies": {
-        "@doist/todoist-api-typescript": "^3.0.3",
+        "@doist/todoist-api-typescript": "^6.10.0",
         "moment": "^2.29.4"
     }
 }

--- a/src/ObsidianFetchAdapter.ts
+++ b/src/ObsidianFetchAdapter.ts
@@ -1,0 +1,45 @@
+import { RequestUrlParam, RequestUrlResponse, requestUrl } from "obsidian";
+
+/**
+ * Custom fetch adapter for Obsidian's requestUrl API.
+ *
+ * Bridges the gap between Obsidian's requestUrl interface and the
+ * standard fetch-like interface expected by the Todoist API SDK v6+.
+ *
+ * Key differences handled:
+ * - Obsidian returns response data as properties (response.json, response.text)
+ *   while the SDK expects methods (response.json(), response.text())
+ * - Obsidian's requestUrl bypasses CORS restrictions that would block standard fetch
+ * - Obsidian throws on HTTP errors by default; we set throw: false to handle manually
+ * - Obsidian doesn't provide statusText; we default to empty string
+ */
+export function obsidianFetch(
+    url: string,
+    options?: RequestInit & { timeout?: number },
+) {
+    return obsidianFetchAdapter(url, options);
+}
+
+async function obsidianFetchAdapter(
+    url: string,
+    options?: RequestInit & { timeout?: number },
+) {
+    const requestParams: RequestUrlParam = {
+        url,
+        method: options?.method || "GET",
+        headers: options?.headers as Record<string, string>,
+        body: options?.body as string,
+        throw: false, // Don't throw on HTTP errors; let the SDK handle status codes
+    };
+
+    const response: RequestUrlResponse = await requestUrl(requestParams);
+
+    return {
+        ok: response.status >= 200 && response.status < 300,
+        status: response.status,
+        statusText: "", // Obsidian doesn't provide statusText
+        headers: response.headers,
+        text: () => Promise.resolve(response.text),
+        json: () => Promise.resolve(response.json),
+    };
+}

--- a/src/SettingTab.ts
+++ b/src/SettingTab.ts
@@ -7,6 +7,7 @@ import {
     Notice,
 } from "obsidian";
 import { TextParsing } from "./TextParsing";
+import { fetchAllPages } from "./TodoistPaginationHelper";
 
 export class TodoistContextBridgeSettingTab extends PluginSettingTab {
     plugin: TodoistContextBridgePlugin;
@@ -48,9 +49,12 @@ export class TodoistContextBridgeSettingTab extends PluginSettingTab {
         // Initialize dropdown with current projects if API is available
         const initializeDropdown = async () => {
             if (!this.plugin.todoistApi || !this.projectsDropdown) return;
+            const api = this.plugin.todoistApi;
 
             try {
-                const projects = await this.plugin.todoistApi.getProjects();
+                const projects = await fetchAllPages((args) =>
+                    api.getProjects(args),
+                );
                 if (projects && this.projectsDropdown) {
                     this.projectsDropdown.selectEl.empty();
                     // this.projectsDropdown.addOption('', 'Inbox (Default)');
@@ -967,7 +971,8 @@ export class TodoistContextBridgeSettingTab extends PluginSettingTab {
     ) {
         try {
             if (!projects && this.plugin.todoistApi) {
-                projects = await this.plugin.todoistApi.getProjects();
+                const api = this.plugin.todoistApi;
+                projects = await fetchAllPages((args) => api.getProjects(args));
             }
 
             if (!projects) {

--- a/src/TodoistModal.ts
+++ b/src/TodoistModal.ts
@@ -1,6 +1,7 @@
 import { Modal, App, Notice, ToggleComponent } from "obsidian";
 import TodoistContextBridgePlugin from "./main";
 import { DateProcessing } from "./DateProcessing";
+import { fetchAllPages } from "./TodoistPaginationHelper";
 
 // Modal for creating Todoist tasks from task text
 export class TaskToTodoistModal extends Modal {
@@ -310,7 +311,11 @@ export class TaskToTodoistModal extends Modal {
         // Load projects and populate dropdown
         const loadProjects = async () => {
             try {
-                const projects = await this.plugin.todoistApi?.getProjects();
+                const api = this.plugin.todoistApi;
+                if (!api) return;
+                const projects = await fetchAllPages((args) =>
+                    api.getProjects(args),
+                );
                 if (projects) {
                     projectSelect.empty();
                     projects.forEach((project) => {
@@ -760,7 +765,11 @@ export class NonTaskToTodoistModal extends Modal {
         // Load projects and populate dropdown
         const loadProjects = async () => {
             try {
-                const projects = await this.plugin.todoistApi?.getProjects();
+                const api = this.plugin.todoistApi;
+                if (!api) return;
+                const projects = await fetchAllPages((args) =>
+                    api.getProjects(args),
+                );
                 if (projects) {
                     projectSelect.empty();
                     projects.forEach((project) => {

--- a/src/TodoistPaginationHelper.ts
+++ b/src/TodoistPaginationHelper.ts
@@ -1,0 +1,38 @@
+import { TodoistApi } from "@doist/todoist-api-typescript";
+
+/**
+ * Helper to fetch all results from paginated Todoist API endpoints.
+ *
+ * The Todoist API v1 uses cursor-based pagination. This helper
+ * handles the pagination loop transparently.
+ */
+
+type PaginatedResponse<T> = {
+    results: T[];
+    nextCursor: string | null;
+};
+
+type PaginatedFetcher<T, A> = (args?: A) => Promise<PaginatedResponse<T>>;
+
+/**
+ * Fetch all pages of results from a paginated API method.
+ * @param fetcher - The paginated API method to call
+ * @param args - Optional arguments to pass to the fetcher
+ * @returns All results concatenated from all pages
+ */
+export async function fetchAllPages<T, A extends { cursor?: string | null }>(
+    fetcher: PaginatedFetcher<T, A>,
+    args?: Omit<A, "cursor">,
+): Promise<T[]> {
+    const allResults: T[] = [];
+    let cursor: string | null = null;
+
+    do {
+        const fetchArgs = { ...args, cursor } as A;
+        const response = await fetcher(fetchArgs);
+        allResults.push(...response.results);
+        cursor = response.nextCursor;
+    } while (cursor);
+
+    return allResults;
+}

--- a/src/TodoistTaskSync.ts
+++ b/src/TodoistTaskSync.ts
@@ -8,6 +8,7 @@ import { UIDProcessing } from "./UIDProcessing"; // Import UIDProcessing
 import { TextParsing, TaskDetails } from "./TextParsing";
 import { TODOIST_CONSTANTS } from "./constants"; // Import TODOIST_CONSTANTS
 import { NotificationHelper } from "./NotificationHelper"; // Import NotificationHelper
+import { fetchAllPages } from "./TodoistPaginationHelper";
 
 export interface TodoistTaskInfo {
     task_id: string;
@@ -204,8 +205,7 @@ export class TodoistTaskSync {
     private async isSharedProject(projectId: string): Promise<boolean> {
         try {
             const project = await this.todoistApi?.getProject(projectId);
-            // In the v1 API, isShared is replaced with is_shared
-            return project ? ((project as any).is_shared ?? false) : false;
+            return project ? (project.isShared ?? false) : false;
         } catch (error) {
             console.warn("Failed to check project sharing status:", error);
             return false;
@@ -233,9 +233,9 @@ export class TodoistTaskSync {
             const taskParams: {
                 content: string;
                 description: string;
-                due_string?: string;
+                dueString?: string;
                 priority?: number;
-                project_id?: string;
+                projectId?: string;
                 labels?: string[];
             } = {
                 content: title.trim(),
@@ -244,7 +244,7 @@ export class TodoistTaskSync {
 
             // Only add non-empty parameters
             if (due_date) {
-                taskParams.due_string = due_date;
+                taskParams.dueString = due_date;
             }
 
             if (priority) {
@@ -252,7 +252,7 @@ export class TodoistTaskSync {
             }
 
             if (project_id || this.settings.todoistDefaultProject) {
-                taskParams.project_id =
+                taskParams.projectId =
                     project_id || this.settings.todoistDefaultProject;
             }
 
@@ -265,7 +265,7 @@ export class TodoistTaskSync {
                 if (this.TextParsing.isValidTodoistLabel(trimmedLabel)) {
                     try {
                         // Check if the target project is shared
-                        const targetProjectId = taskParams.project_id;
+                        const targetProjectId = taskParams.projectId;
                         const isShared = targetProjectId
                             ? await this.isSharedProject(targetProjectId)
                             : false;
@@ -279,7 +279,10 @@ export class TodoistTaskSync {
                         }
 
                         // Create or get the label
-                        const labels = await this.todoistApi.getLabels();
+                        const labelApi = this.todoistApi;
+                        const labels = await fetchAllPages((args) =>
+                            labelApi.getLabels(args),
+                        );
                         const existingLabel = labels.find(
                             (l) => l.name === trimmedLabel,
                         );
@@ -812,8 +815,7 @@ export class TodoistTaskSync {
                     const task = await this.todoistApi.getTask(localTaskId);
                     return {
                         task_id: localTaskId,
-                        is_completed:
-                            (task as any).checked ?? task.isCompleted ?? false,
+                        is_completed: task.checked ?? false,
                     };
                 } catch (error) {
                     // Task might have been deleted in Todoist, continue searching
@@ -824,7 +826,10 @@ export class TodoistTaskSync {
             }
 
             // Search in Todoist for tasks with matching Advanced URI or block ID
-            const activeTasks = await this.todoistApi.getTasks();
+            const taskApi = this.todoistApi;
+            const activeTasks = await fetchAllPages((args) =>
+                taskApi.getTasks(args),
+            );
             const matchingTask = activeTasks.find(
                 (task) =>
                     task.description &&
@@ -835,10 +840,7 @@ export class TodoistTaskSync {
             if (matchingTask) {
                 return {
                     task_id: matchingTask.id,
-                    is_completed:
-                        (matchingTask as any).checked ??
-                        matchingTask.isCompleted ??
-                        false,
+                    is_completed: matchingTask.checked ?? false,
                 };
             }
 
@@ -1025,8 +1027,7 @@ export class TodoistTaskSync {
             }
 
             // Check if task is completed
-            const isTaskCompleted =
-                (task as any).checked ?? task.isCompleted ?? false;
+            const isTaskCompleted = task.checked ?? false;
             if (isTaskCompleted) {
                 new Notice("This task is already completed in Todoist.");
                 return;

--- a/src/TodoistToObsidianModal.ts
+++ b/src/TodoistToObsidianModal.ts
@@ -2,6 +2,7 @@ import { Modal, App, Notice } from "obsidian";
 import TodoistContextBridgePlugin from "./main";
 import { Task } from "@doist/todoist-api-typescript";
 import { TodoistV2IDs } from "./TodoistV2IDs";
+import { fetchAllPages } from "./TodoistPaginationHelper";
 
 /**
  * Modal for syncing a task from Todoist to Obsidian
@@ -166,12 +167,15 @@ export class TodoistToObsidianModal extends Modal {
 
                 // Initialize our task match variable
                 let matchedTask: Task | null = null;
+                const api = this.plugin.todoistApi;
 
                 // First, fetch all tasks once so we have them available for multiple matching attempts
 
                 let allTasks: Task[] = [];
                 try {
-                    allTasks = await this.plugin.todoistApi.getTasks();
+                    allTasks = await fetchAllPages((args) =>
+                        api.getTasks(args),
+                    );
                 } catch (error) {
                     // Continue with direct ID attempts anyway
                 }
@@ -257,8 +261,9 @@ export class TodoistToObsidianModal extends Modal {
 
                     // Get all tasks and filter on the client side
                     if (words.length > 0) {
-                        const allTasks =
-                            await this.plugin.todoistApi.getTasks();
+                        const allTasks = await fetchAllPages((args) =>
+                            api.getTasks(args),
+                        );
 
                         if (allTasks && allTasks.length > 0) {
                             // Filter tasks that contain any of our significant words
@@ -317,8 +322,9 @@ export class TodoistToObsidianModal extends Modal {
                     try {
                         // Fetch all tasks if we haven't done so already
 
-                        const allTasks =
-                            await this.plugin.todoistApi.getTasks();
+                        const allTasks = await fetchAllPages((args) =>
+                            api.getTasks(args),
+                        );
 
                         // Try exact URL matching with the original input
                         const originalUrl = this.taskLinkInput.trim();

--- a/src/TodoistV2IDs.ts
+++ b/src/TodoistV2IDs.ts
@@ -1,48 +1,53 @@
+import { TodoistApi } from "@doist/todoist-api-typescript";
 import { TodoistContextBridgeSettings } from "./Settings";
 
 /**
  * Helper class to handle v2 (alphanumeric) Todoist IDs
  * Provides methods to work with both numeric and v2 IDs
+ *
+ * Note: In the new Todoist API v1, all IDs are already alphanumeric strings.
+ * This class primarily handles backward compatibility with old numeric IDs
+ * that may still exist in Obsidian notes.
  */
 export class TodoistV2IDs {
+    private todoistApi: TodoistApi | null = null;
+
     constructor(private settings: TodoistContextBridgeSettings) {}
 
     /**
-     * Get the v2 (alphanumeric) ID for a task using the Todoist Sync API
+     * Set the TodoistApi instance for making API calls
+     */
+    public setApi(api: TodoistApi | null) {
+        this.todoistApi = api;
+    }
+
+    /**
+     * Get the v2 (alphanumeric) ID for a task using the Todoist API
      * @param numericId The numeric ID of the task
      * @returns Promise resolving to the v2 ID if found, or the numeric ID as fallback
      */
     public async getV2Id(numericId: string): Promise<string> {
         if (!numericId) return "";
-        if (!this.settings.todoistAPIToken) {
-            console.warn("No Todoist API token found, cannot fetch v2 ID");
+
+        // If it's already alphanumeric, return as-is
+        if (/[a-zA-Z]/.test(numericId)) {
+            return numericId;
+        }
+
+        if (!this.todoistApi) {
+            console.warn(
+                "No Todoist API instance available, cannot fetch v2 ID",
+            );
             return numericId;
         }
 
         try {
-            // Using the Todoist Sync API to get task details including v2_id
-            const response = await fetch(
-                `https://api.todoist.com/sync/v9/items/get?item_id=${numericId}`,
-                {
-                    method: "GET",
-                    headers: {
-                        Authorization: `Bearer ${this.settings.todoistAPIToken}`,
-                    },
-                },
-            );
-
-            if (!response.ok) {
-                throw new Error(`Failed to get task info: ${response.status}`);
+            // Use the SDK's getTask method to fetch the task and get its string ID
+            const task = await this.todoistApi.getTask(numericId);
+            if (task && task.id) {
+                return task.id;
             }
-
-            const data = await response.json();
-
-            // Check if v2_id exists in the response
-            if (data && data.item && data.item.v2_id) {
-                return data.item.v2_id;
-            } else {
-                return numericId;
-            }
+            return numericId;
         } catch (error) {
             console.error("Error fetching v2 ID:", error);
             // Fallback to numeric ID if we can't fetch the v2 ID

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,10 @@
 import { Editor, Notice, Plugin } from "obsidian";
-import { TodoistApi, Project, Task } from "@doist/todoist-api-typescript";
+import {
+    TodoistApi,
+    PersonalProject,
+    WorkspaceProject,
+    Task,
+} from "@doist/todoist-api-typescript";
 import { DEFAULT_SETTINGS, TodoistContextBridgeSettings } from "./Settings";
 import { TodoistContextBridgeSettingTab } from "./SettingTab";
 import { UIDProcessing } from "./UIDProcessing";
@@ -9,11 +14,13 @@ import { TextParsing } from "./TextParsing";
 import { DateProcessing } from "./DateProcessing"; // Import DateProcessing
 import { TodoistToObsidianModal } from "./TodoistToObsidianModal"; // Import the new modal
 import { TodoistV2IDs } from "./TodoistV2IDs"; // Import the v2 ID helper
+import { obsidianFetch } from "./ObsidianFetchAdapter"; // Import custom fetch adapter
+import { fetchAllPages } from "./TodoistPaginationHelper";
 
 export default class TodoistContextBridgePlugin extends Plugin {
     settings: TodoistContextBridgeSettings;
     todoistApi: TodoistApi | null = null;
-    projects: Project[] = [];
+    projects: (PersonalProject | WorkspaceProject)[] = [];
 
     private UIDProcessing: UIDProcessing;
     private TodoistTaskSync: TodoistTaskSync;
@@ -188,9 +195,11 @@ export default class TodoistContextBridgePlugin extends Plugin {
 
     async loadProjects() {
         try {
-            const projects = await this.todoistApi?.getProjects();
-            if (projects) {
-                // Store projects or update UI as needed
+            const api = this.todoistApi;
+            if (api) {
+                this.projects = await fetchAllPages((args) =>
+                    api.getProjects(args),
+                );
             }
         } catch (error) {
             console.error("Failed to load Todoist projects:", error);
@@ -202,9 +211,14 @@ export default class TodoistContextBridgePlugin extends Plugin {
 
     public initializeTodoistApi() {
         if (this.settings.todoistAPIToken) {
-            this.todoistApi = new TodoistApi(this.settings.todoistAPIToken);
+            this.todoistApi = new TodoistApi(this.settings.todoistAPIToken, {
+                customFetch: obsidianFetch,
+            });
+            // Set API instance on v2 ID helper
+            this.TodoistV2IDs.setApi(this.todoistApi);
         } else {
             this.todoistApi = null;
+            this.TodoistV2IDs.setApi(null);
         }
     }
 
@@ -234,12 +248,17 @@ export default class TodoistContextBridgePlugin extends Plugin {
         }
     }
 
-    async verifyTodoistToken(
-        token: string,
-    ): Promise<{ success: boolean; projects?: Project[] }> {
+    async verifyTodoistToken(token: string): Promise<{
+        success: boolean;
+        projects?: (PersonalProject | WorkspaceProject)[];
+    }> {
         try {
-            const tempApi = new TodoistApi(token);
-            const projects = await tempApi.getProjects();
+            const tempApi = new TodoistApi(token, {
+                customFetch: obsidianFetch,
+            });
+            const projects = await fetchAllPages((args) =>
+                tempApi.getProjects(args),
+            );
             return { success: true, projects };
         } catch (error) {
             console.error("Token verification failed:", error);


### PR DESCRIPTION
- upgrade @doist/todoist-api-typescript from ^3.0.3 to ^6.10.0
- add ObsidianFetchAdapter to bridge Obsidian's requestUrl with SDK's fetch interface
- add TodoistPaginationHelper for cursor-based pagination in new API
- update all API calls to use camelCase field names (dueString, projectId, isShared)
- replace raw Sync API fetch in TodoistV2IDs with SDK's getTask method
- add undici and node: prefixed builtins to esbuild externals

fix #18 